### PR TITLE
Autocomplete places

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "axios": "^1.3.2",
     "phosphor-react": "^1.4.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "use-places-autocomplete": "^4.0.0"
   },
   "devDependencies": {
-    "@types/leaflet": "^1.9.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@react-google-maps/api': ^2.18.1
   '@tanstack/react-query': ^4.24.6
-  '@types/leaflet': ^1.9.0
   '@types/react': ^18.0.27
   '@types/react-dom': ^18.0.10
   '@typescript-eslint/eslint-plugin': ^5.0.0
@@ -23,6 +22,7 @@ specifiers:
   react-dom: ^18.2.0
   tailwindcss: ^3.2.6
   typescript: ^4.9.5
+  use-places-autocomplete: ^4.0.0
   vite: ^4.1.0
 
 dependencies:
@@ -32,9 +32,9 @@ dependencies:
   phosphor-react: 1.4.1_react@18.2.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  use-places-autocomplete: 4.0.0_react@18.2.0
 
 devDependencies:
-  '@types/leaflet': 1.9.0
   '@types/react': 18.0.28
   '@types/react-dom': 18.0.10
   '@typescript-eslint/eslint-plugin': 5.51.0_z4swst3wuuqk4hlme4ajzslgh4
@@ -476,10 +476,6 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@types/geojson/7946.0.10:
-    resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==}
-    dev: true
-
   /@types/google.maps/3.50.5:
     resolution: {integrity: sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw==}
     dev: false
@@ -490,12 +486,6 @@ packages:
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-    dev: true
-
-  /@types/leaflet/1.9.0:
-    resolution: {integrity: sha512-7LeOSj7EloC5UcyOMo+1kc3S1UT3MjJxwqsMT1d2PTyvQz53w0Y0oSSk9nwZnOZubCmBvpSNGceucxiq+ZPEUw==}
-    dependencies:
-      '@types/geojson': 7946.0.10
     dev: true
 
   /@types/prop-types/15.7.5:
@@ -2579,6 +2569,14 @@ packages:
     dependencies:
       punycode: 2.3.0
     dev: true
+
+  /use-places-autocomplete/4.0.0_react@18.2.0:
+    resolution: {integrity: sha512-w8jdm1iT3WXN0DPXtgyccJoBlAk/UetCMg466B2pBiWNBfvAIxdRoU6Gt4CzW11rWWuzpqnMG5hLxUOKSZBSgw==}
+    peerDependencies:
+      react: '>= 16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /use-sync-external-store/1.2.0_react@18.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}

--- a/src/@types/interfaces.ts
+++ b/src/@types/interfaces.ts
@@ -1,0 +1,5 @@
+export interface LatLng {
+  id: string;
+  lat: number;
+  lng: number;
+}

--- a/src/@types/interfaces.ts
+++ b/src/@types/interfaces.ts
@@ -1,5 +1,10 @@
 export interface LatLng {
   id: string;
+  displayText: string;
   lat: number;
   lng: number;
+}
+
+export interface Route {
+  stops: LatLng[];
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,50 @@
-import { type ReactElement, useMemo } from 'react';
+/* eslint-disable @typescript-eslint/indent */
+/* eslint-disable multiline-ternary */
+import { type ReactElement, useMemo, useState } from 'react';
 import { InfoOverlay } from './components/InfoOverlay';
 import { SearchBar } from './components/SearchBar';
-import { GoogleMap, useLoadScript } from '@react-google-maps/api';
+import { GoogleMap, useLoadScript, Marker } from '@react-google-maps/api';
+import { type LatLng } from './@types/interfaces';
+
+const libraries = ['places'];
 
 function App(): ReactElement {
   const { isLoaded } = useLoadScript({
-    googleMapsApiKey: import.meta.env.VITE_GEOCODING_API_KEY
+    googleMapsApiKey: import.meta.env.VITE_GEOCODING_API_KEY,
+    libraries
   });
-  const center = useMemo(() => ({ lat: 44, lng: -80 }), [])
+  const center = useMemo(() => ({ lat: -5.1, lng: -42.9 }), []);
+
+  const [selected, setSelected] = useState<LatLng[]>([]);
+  const hasSelectedPlaces = selected?.length > 0;
   return (
     <div className="flex flex-col relative w-screen h-screen items-center">
-      {isLoaded
-        ? (
+      {isLoaded ? (
         <>
           <GoogleMap
             zoom={10}
-            center={center}
+            center={selected.length > 0 ? selected.at(-1) : center}
             mapContainerClassName="w-full h-full"
-          ></GoogleMap>
-          <SearchBar />
-          <InfoOverlay />
+          >
+            {hasSelectedPlaces
+              ? selected.map((position) => {
+                  return <Marker key={position.id} position={position} />;
+                })
+              : null}
+          </GoogleMap>
+          <SearchBar
+            onSelected={(location) => {
+              setSelected([...selected, location]);
+            }}
+          />
+          <InfoOverlay
+            title={!hasSelectedPlaces ? 'Últimas rotas' : 'Nova rota'}
+            selectedPlaces={selected}
+          />
         </>
-          )
-        : (
+      ) : (
         <div className="w-20 h-20 border-l-2 border-b-2 border-slate-800 rounded-full animate-spin"></div>
-          )}
+      )}
     </div>
   );
 }

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -1,8 +1,14 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { RouteInfo } from './RouteInfo';
+import { type LatLng } from '../@types/interfaces';
 
-export function InfoOverlay(): ReactElement {
+interface InfoOverlayProps {
+  title: string;
+  selectedPlaces: LatLng[];
+}
+
+export function InfoOverlay({ title }: InfoOverlayProps): ReactElement {
   const [expanded, setExpanded] = useState(false);
 
   function toggleExpanded(): void {
@@ -15,8 +21,8 @@ export function InfoOverlay(): ReactElement {
                  w-full md:w-3/5 md:py-4 rounded-lg flex flex-col align-center
                  drop-shadow-lg transition-all ${
                    expanded
-                     ? 'h-2/3 overflow-y-scroll'
-                     : 'h-1/3 overflow-y-hidden'
+                     ? 'h-2/3 max-h-full overflow-y-scroll'
+                     : 'h-1/3 max-h-1/2 overflow-y-hidden'
                  }`}
     >
       <div
@@ -24,7 +30,7 @@ export function InfoOverlay(): ReactElement {
         onClick={toggleExpanded}
       ></div>
       <h1 className="font-bold text-3xl w-full font-title ml-8 mb-4">
-        Últimas rotas
+        {title}
       </h1>
       <div>
         <RouteInfo stops={2} />

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,18 +1,69 @@
 import { MagnifyingGlass } from 'phosphor-react';
 import { type ReactElement } from 'react';
+import usePlacesAutocomplete from 'use-places-autocomplete';
+import { type LatLng } from '../@types/interfaces';
+import { fetchAddresses } from '../lib/api/geocoding';
 
-export function SearchBar(): ReactElement {
+interface SearchBarProps {
+  onSelected: (location: LatLng) => void;
+}
+
+export function SearchBar({ onSelected }: SearchBarProps): ReactElement {
+  const {
+    ready,
+    value,
+    setValue,
+    suggestions: { status, data },
+    clearSuggestions
+  } = usePlacesAutocomplete();
+
+  async function handleSelectLocation(placeId: string): Promise<void> {
+    const location = await fetchAddresses(placeId);
+    onSelected({
+      lat: location.lat,
+      lng: location.lng
+    });
+    clearSuggestions();
+  }
+
   return (
-    <div className="relative top-2 h-16 w-3/5 z-10 flex items-center rounded-lg drop-shadow-lg">
-      <MagnifyingGlass
-        className="bg-white text-slate-500 rounded-r-lg h-12 pr-2 drop-shadow-r-lg"
-        size={32}
-        mirrored
-      />
-      <input
-        className="bg-white placeholder:text-slate-500 p-2 w-full h-12 rounded-r-lg outline-none drop-shadow-t-lg drop-shadow-rb"
-        placeholder="Busque um endereço para iniciar uma nova rota"
-      />
+    <div className="absolute top-2 h-16 w-3/5 z-10 flex flex-col items-center rounded-lg drop-shadow-lg">
+      <div className="flex w-full">
+        <MagnifyingGlass
+          className="bg-white text-slate-500 rounded-r-lg h-12 pr-2 drop-shadow-r-lg"
+          size={32}
+          mirrored
+        />
+        <input
+          className="bg-white placeholder:text-slate-500 p-2 w-full h-12 rounded-r-lg outline-none drop-shadow-t-lg drop-shadow-rb"
+          placeholder="Busque um endereço para iniciar uma nova rota"
+          value={value}
+          disabled={!ready}
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+        />
+      </div>
+      {status === 'OK'
+        ? (
+        <ul className="bg-white flex flex-col z-10 w-full rounded-lg mt-2 p-2 gap-2">
+          {data.map(({ place_id: placeId, description }) => {
+            return (
+              <li
+                className="border-b-2 border-slate-300 max-w-full cursor-pointer"
+                key={placeId}
+                onClick={() => {
+                  setValue(description, false)
+                  void handleSelectLocation(placeId);
+                }}
+              >
+                {description}
+              </li>
+            );
+          })}
+        </ul>
+          )
+        : null}
     </div>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -20,8 +20,10 @@ export function SearchBar({ onSelected }: SearchBarProps): ReactElement {
   async function handleSelectLocation(placeId: string): Promise<void> {
     const location = await fetchAddresses(placeId);
     onSelected({
+      displayText: location.displayName,
       lat: location.lat,
-      lng: location.lng
+      lng: location.lng,
+      id: placeId
     });
     clearSuggestions();
   }
@@ -44,8 +46,7 @@ export function SearchBar({ onSelected }: SearchBarProps): ReactElement {
           }}
         />
       </div>
-      {status === 'OK'
-        ? (
+      {status === 'OK' ? (
         <ul className="bg-white flex flex-col z-10 w-full rounded-lg mt-2 p-2 gap-2">
           {data.map(({ place_id: placeId, description }) => {
             return (
@@ -53,7 +54,7 @@ export function SearchBar({ onSelected }: SearchBarProps): ReactElement {
                 className="border-b-2 border-slate-300 max-w-full cursor-pointer"
                 key={placeId}
                 onClick={() => {
-                  setValue(description, false)
+                  setValue(description, false);
                   void handleSelectLocation(placeId);
                 }}
               >
@@ -62,8 +63,7 @@ export function SearchBar({ onSelected }: SearchBarProps): ReactElement {
             );
           })}
         </ul>
-          )
-        : null}
+      ) : null}
     </div>
   );
 }

--- a/src/lib/api/geocoding.ts
+++ b/src/lib/api/geocoding.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+const geocodingProvider = axios.create({
+  baseURL: import.meta.env.VITE_GEOCODING_API_BASE_URL
+});
+
+interface LocationApiResponse {
+  results: Array<{
+    geometry: {
+      location: {
+        lat: number;
+        lng: number;
+      };
+    };
+    place_id: string;
+    formatted_address: string;
+  }>;
+  status: string;
+}
+
+export interface Location {
+  placeId: string;
+  lat: number;
+  lng: number;
+  displayName: string;
+}
+
+const geocodingCancelTokenSource = axios.CancelToken.source();
+
+export async function fetchAddresses(id: string): Promise<Location> {
+  const response = await geocodingProvider.get<LocationApiResponse>('', {
+    params: {
+      place_id: id,
+      key: import.meta.env.VITE_GEOCODING_API_KEY
+    },
+    cancelToken: geocodingCancelTokenSource.token
+  });
+  const {
+    place_id: placeId,
+    geometry,
+    formatted_address: displayName
+  } = response.data.results[0];
+  const location: Location = {
+    placeId,
+    lat: geometry.location.lat,
+    lng: geometry.location.lng,
+    displayName
+  };
+  return location;
+}
+
+export function cancelGeocodeRequest(): void {
+  geocodingCancelTokenSource.cancel();
+}


### PR DESCRIPTION
# Summary

This pr implements the search bar autocompletion using the
Google Places API.

Each time the user clicks on a suggestion, it appends to
a list of selected places that are shown on the
InfoOverlay, in the bottom of the page

# Commits
- refactor(types): Export interfaces from a common place
- feat(autocomplete): Setup autocompletion for places in the ui and set props to store them
- refactor(InfoOverlay): Let title be dynamic and pass the selected places for display if needed
- refactor(api): Use axios to consume a geocoding api (Google's one in that case)
- refactor(types): Add address description information to the LatLng type
