### PR TITLE
refactor(locations->stops): Rename all location to stop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,9 @@
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable multiline-ternary */
-import {
-  type ReactElement,
-  useMemo,
-  useState,
-  useCallback,
-  useEffect
-} from 'react';
+import { type ReactElement, useState, useCallback, useEffect } from 'react';
 import { InfoOverlay } from './components/InfoOverlay';
 import { SearchBar } from './components/SearchBar';
-import { GoogleMap, useLoadScript, Marker } from '@react-google-maps/api';
+import { useLoadScript } from '@react-google-maps/api';
 import { useLocations } from './hooks/use-selected-locations';
 import { useRoutes } from './hooks/use-routes';
 import { Map } from './components/Map';
@@ -26,19 +20,20 @@ function App(): ReactElement {
 
   const { saveRoute, routes } = useRoutes();
   const {
-    locations,
-    appendLocation,
-    removeLocation,
-    hasSelectedLocations,
+    stops,
+    appendStop,
+    removeStop,
+    hasSelectedStops,
     moveTowardsEnd,
     moveTowardsStart,
-    clearLocations
+    clearStops,
+    setStops
   } = useLocations();
 
   useEffect(() => {
-    if (locations.length > 0 && map) {
+    if (stops.length > 0 && map) {
       const bounds = new google.maps.LatLngBounds();
-      locations.forEach((loc) => {
+      stops.forEach((loc) => {
         bounds.extend({
           lat: loc.lat,
           lng: loc.lng
@@ -46,7 +41,7 @@ function App(): ReactElement {
       });
       map.fitBounds(bounds);
     }
-  }, [map, locations]);
+  }, [map, stops]);
   useEffect(() => {
     if (map) {
       map.setOptions({
@@ -61,18 +56,19 @@ function App(): ReactElement {
         <>
           <Map
             onLoad={onLoad}
-            hasSelectedLocations={hasSelectedLocations}
-            locations={locations}
+            hasSelectedStops={hasSelectedStops}
+            locations={stops}
           />
-          <SearchBar onSelected={appendLocation} />
+          <SearchBar onSelected={appendStop} />
           <InfoOverlay
-            title={!hasSelectedLocations ? 'Últimas rotas' : 'Nova rota'}
+            setStops={setStops}
+            title={!hasSelectedStops ? 'Últimas rotas' : 'Nova rota'}
             existingRoutes={routes}
-            clearLocations={clearLocations}
+            clearStops={clearStops}
             saveRoute={saveRoute}
-            selectedLocations={locations}
-            removeLocation={removeLocation}
-            hasSelectedLocations={hasSelectedLocations}
+            selectedStops={stops}
+            removeStop={removeStop}
+            hasSelectedStops={hasSelectedStops}
             moveTowardsEnd={moveTowardsEnd}
             moveTowardsStart={moveTowardsStart}
           />

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -2,30 +2,32 @@ import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Route, type Location } from '../@types/interfaces';
 import { RoutesList } from './RoutesList';
-import { NewRouteStops } from './NewRouteStops';
+import { RouteStops } from './RouteStops';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 
 interface InfoOverlayProps {
   title: string;
-  selectedLocations: Location[];
+  selectedStops: Location[];
   existingRoutes: Route[];
-  hasSelectedLocations: boolean;
-  removeLocation: (locationId: string) => void;
+  hasSelectedStops: boolean;
+  removeStop: (locationId: string) => void;
   moveTowardsEnd: (location: Location) => void;
   moveTowardsStart: (location: Location) => void;
+  setStops: (locations: Location[]) => void;
   saveRoute: (stops: Location[]) => void;
-  clearLocations: () => void;
+  clearStops: () => void;
 }
 
 export function InfoOverlay({
   title,
-  selectedLocations,
-  removeLocation,
-  hasSelectedLocations,
+  selectedStops,
+  removeStop,
+  hasSelectedStops,
   moveTowardsEnd,
   moveTowardsStart,
   existingRoutes,
-  clearLocations,
+  clearStops,
+  setStops,
   saveRoute
 }: InfoOverlayProps): ReactElement {
   const [expanded, setExpanded] = useState(false);
@@ -44,10 +46,10 @@ export function InfoOverlay({
                      : 'h-1/3 max-h-1/2 overflow-y-hidden'
                  }`}
     >
-      {hasSelectedLocations ? (
+      {hasSelectedStops ? (
         <button
           className="text-white bg-slate-700 font-bold rounded-lg p-2 drop-shadow-lg w-fit absolute top-4 right-4"
-          onClick={clearLocations}
+          onClick={clearStops}
         >
           Cancelar
         </button>
@@ -60,17 +62,17 @@ export function InfoOverlay({
         {title}
       </h1>
       <div ref={parent}>
-        {hasSelectedLocations ? (
-          <NewRouteStops
-            stops={selectedLocations}
-            clearLocations={clearLocations}
-            removeLocation={removeLocation}
+        {hasSelectedStops ? (
+          <RouteStops
+            stops={selectedStops}
+            clearStops={clearStops}
+            removeStop={removeStop}
             moveTowardsEnd={moveTowardsEnd}
             moveTowardsStart={moveTowardsStart}
             saveRoute={saveRoute}
           />
         ) : (
-          <RoutesList routes={existingRoutes} />
+          <RoutesList routes={existingRoutes} setStops={setStops} />
         )}
       </div>
     </div>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,11 +4,11 @@ import { Location } from '../@types/interfaces';
 
 interface MapProps {
   onLoad: (map: google.maps.Map) => void;
-  hasSelectedLocations: boolean;
+  hasSelectedStops: boolean;
   locations: Location[];
 }
 
-export function Map({ onLoad, locations, hasSelectedLocations }: MapProps) {
+export function Map({ onLoad, locations, hasSelectedStops }: MapProps) {
   const center = useMemo(() => {
     let location = { lat: -5.09, lng: -42.8 };
     return location;
@@ -18,10 +18,10 @@ export function Map({ onLoad, locations, hasSelectedLocations }: MapProps) {
     <GoogleMap
       onLoad={onLoad}
       zoom={zoom}
-      center={hasSelectedLocations ? locations.at(-1) : center}
+      center={hasSelectedStops ? locations.at(-1) : center}
       mapContainerClassName="w-full h-full"
     >
-      {hasSelectedLocations &&
+      {hasSelectedStops &&
         locations.map((location) => {
           return <Marker key={location.id} position={location} />;
         })}

--- a/src/components/RouteInfo.tsx
+++ b/src/components/RouteInfo.tsx
@@ -1,17 +1,23 @@
 import type { ReactElement } from 'react';
 import { MapPin, DotsThree } from 'phosphor-react';
-import { Route } from '../@types/interfaces';
+import { Location, Route } from '../@types/interfaces';
 
 interface RouteInfoProps {
   route: Route;
+  setStops: (stops: Location[]) => void;
 }
 
-export function RouteInfo({ route }: RouteInfoProps): ReactElement {
+export function RouteInfo({ route, setStops }: RouteInfoProps): ReactElement {
   const start = route.stops[0];
   const end = route.stops.at(-1)!;
   const extraStops = route.stops.length - 2;
   return (
-    <div className="grid grid-cols-3 space-around w-full border-t-2 border-slate-500 px-8 py-4">
+    <div
+      className="grid grid-cols-3 space-around w-full border-t-2 border-slate-500 px-8 py-4 cursor-pointer"
+      onClick={() => {
+        setStops(route.stops);
+      }}
+    >
       <div className="flex flex-col text-center items-center justify-center gap-4 px-8">
         <p className="font-medium text-2xl">Partida</p>
         <MapPin size={32} />

--- a/src/components/RouteStops.tsx
+++ b/src/components/RouteStops.tsx
@@ -6,26 +6,26 @@ import { SaveRouteButton } from './SaveRouteButton';
 
 interface NewRouteStopsProps {
   stops: Location[];
-  removeLocation: (locationId: string) => void;
+  removeStop: (locationId: string) => void;
   moveTowardsStart: (location: Location) => void;
   moveTowardsEnd: (location: Location) => void;
   saveRoute: (stops: Location[]) => void;
-  clearLocations: () => void;
+  clearStops: () => void;
 }
 
-export function NewRouteStops({
+export function RouteStops({
   stops,
-  removeLocation,
+  removeStop,
   moveTowardsStart,
   moveTowardsEnd,
   saveRoute,
-  clearLocations
+  clearStops
 }: NewRouteStopsProps): ReactElement {
   const [parent] = useAutoAnimate();
 
   function handleSaveRoute(stops: Location[]) {
     saveRoute(stops);
-    clearLocations();
+    clearStops();
   }
 
   return (
@@ -79,7 +79,7 @@ export function NewRouteStops({
                 <X
                   className="text-red-500 cursor-pointer"
                   size={24}
-                  onClick={() => removeLocation(location.id)}
+                  onClick={() => removeStop(location.id)}
                 />
               </div>
             </div>

--- a/src/components/RoutesList.tsx
+++ b/src/components/RoutesList.tsx
@@ -1,17 +1,21 @@
 import { type ReactElement } from 'react';
-import { Route } from '../@types/interfaces';
+import { Location, Route } from '../@types/interfaces';
 import { RouteInfo } from './RouteInfo';
 
 interface RoutesListProps {
   routes: Route[];
+  setStops: (locations: Location[]) => void;
 }
 
-export function RoutesList({ routes }: RoutesListProps): ReactElement {
+export function RoutesList({
+  routes,
+  setStops
+}: RoutesListProps): ReactElement {
   return (
     <>
       {routes.length > 0 ? (
         routes?.map((route) => {
-          return <RouteInfo key={route.id} route={route} />;
+          return <RouteInfo key={route.id} route={route} setStops={setStops} />;
         })
       ) : (
         <p className="font-bold text-2xl text-center w-full">

--- a/src/hooks/use-selected-locations.ts
+++ b/src/hooks/use-selected-locations.ts
@@ -2,54 +2,55 @@ import { useState } from 'react';
 import { Location } from '../@types/interfaces';
 
 export function useLocations() {
-  const [locations, setLocations] = useState<Location[]>([]);
-  const hasSelectedLocations = locations.length > 0;
+  const [stops, setStops] = useState<Location[]>([]);
+  const hasSelectedStops = stops.length > 0;
 
-  function clearLocations() {
-    setLocations([]);
+  function clearStops() {
+    setStops([]);
   }
 
   function moveTowardsEnd(location: Location) {
-    const index = locations.findIndex((loc) => loc.id === location.id);
+    const index = stops.findIndex((loc) => loc.id === location.id);
     if (index === -1) {
       throw new Error('Localização com id não presente');
     }
-    if (index === locations.length - 1) {
+    if (index === stops.length - 1) {
       return;
     }
-    const locationsCopy = [...locations];
+    const locationsCopy = [...stops];
     locationsCopy[index] = locationsCopy[index + 1];
     locationsCopy[index + 1] = location;
-    setLocations(locationsCopy);
+    setStops(locationsCopy);
   }
   function moveTowardsStart(location: Location) {
-    const index = locations.findIndex((loc) => loc.id === location.id);
+    const index = stops.findIndex((loc) => loc.id === location.id);
     if (index === -1) {
       throw new Error('Localização com id não presente');
     }
     if (index === 0) {
       return;
     }
-    const locationsCopy = [...locations];
+    const locationsCopy = [...stops];
     locationsCopy[index] = locationsCopy[index - 1];
     locationsCopy[index - 1] = location;
-    setLocations(locationsCopy);
+    setStops(locationsCopy);
   }
-  function appendLocation(location: Location) {
-    setLocations((locs) => [...locs, location]);
+  function appendStop(location: Location) {
+    setStops((locs) => [...locs, location]);
   }
 
-  function removeLocation(locationId: string) {
-    setLocations((locs) => locs.filter((loc) => loc.id !== locationId));
+  function removeStop(locationId: string) {
+    setStops((locs) => locs.filter((loc) => loc.id !== locationId));
   }
 
   return {
-    locations,
-    hasSelectedLocations,
-    appendLocation,
-    clearLocations,
-    removeLocation,
+    stops,
+    hasSelectedStops,
+    appendStop,
+    clearStops,
+    removeStop,
     moveTowardsEnd,
-    moveTowardsStart
+    moveTowardsStart,
+    setStops
   };
 }


### PR DESCRIPTION
This commit renames all variables that have the string `location` in the name. This was done to avoid confunsion between what is a stop and what is a location.

Location in this context is something that has coordinates , an id and a display name. Stop, is some location that the user wants to visit in a route, including the starting point and the end point of said route. This commit also implements a way to visualize existing routes on the map